### PR TITLE
Update notification.stub

### DIFF
--- a/src/notification.stub
+++ b/src/notification.stub
@@ -16,9 +16,10 @@ class DummyClass extends Notification
      *
      * @return void
      */
-    public function __construct($event = null)
+    public function __construct($config = [])
     {
-        parent::__construct($event);
+        $config = ['event' => $config];
+        parent::__construct($config);
     }
 
     /**


### PR DESCRIPTION
Passing an event into the __construct function has been deprecated, this is throwing deprecation errors in the CP.
I fixed it the following way.