### PR TITLE
Add helper function to get all "read" notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ use percipioglobal\notifications\Notifications;
 // All unread notifications
 Notifications::getInstance()->notificationsService->getAllUnread();
 
+// All read notifications
+Notifications::getInstance()->notificationsService->getAllRead();
+
 // All notifications
 Notifications::getInstance()->notificationsService->getAll();
 ```

--- a/src/services/NotificationsService.php
+++ b/src/services/NotificationsService.php
@@ -161,6 +161,27 @@ class NotificationsService extends Component
         return [];
     }
 
+	/**
+	 * Get all read notifications for a certain User
+	 *
+	 * @param User|null $user
+	 *
+	 * @return array
+	 */
+	public function getAllRead(User $user = null): array
+	{
+		// If there's no passed user, get the current logged in user
+		$user = $user ?? Craft::$app->getUser();
+
+		if ($user) {
+			$notifications = NotificationsRecord::find()->where(['notifiable' => $user->id])->andWhere(['not', ['read_at' => null]])->all();
+			return $this->formatNotificationData($notifications)->toArray();
+		}
+
+		// No notifications when we don't have a passed in or logged in user
+		return [];
+	}
+
     /**
      * Mark a notification as read
      *

--- a/src/variables/NotificationsVariable.php
+++ b/src/variables/NotificationsVariable.php
@@ -51,6 +51,18 @@ class NotificationsVariable
         return Notifications::$plugin->notificationsService->getAllUnread($user);
     }
 
+	/**
+	 * Return all read notifications
+	 *
+	 * @param null $user
+	 *
+	 * @return array
+	 */
+	public function read($user = null): array
+	{
+		return Notifications::$plugin->notificationsService->getAllRead($user);
+	}
+
     public function markAsRead($notification = null)
     {
         return Notifications::$plugin->notificationsService->markAsRead($notification);


### PR DESCRIPTION
Adding a new helper function to to get all "Read" notifications.

There is currently a way to get: 

- All notifications
- Unread Notifications

This adds a way to get the "Read" notifications, instead of having to manipulate one of the above functions results.